### PR TITLE
fix: update version to 1.0.8-beta in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lazyshell",
-  "version": "1.0.7-beta",
+  "version": "1.0.8-beta",
   "description": "",
   "main": "bin/lazyshell",
   "bin": {


### PR DESCRIPTION
This pull request includes a version bump in the `package.json` file to prepare for a new release.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `1.0.7-beta` to `1.0.8-beta` to reflect the upcoming release.