### PR TITLE
Refactor CI workflow for evals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,12 @@ name: CI
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'src/lib/ai.ts'
   pull_request:
     branches: [ main ]
+    paths:
+      - 'src/lib/ai.ts'
 
 jobs:
   test:
@@ -39,7 +43,6 @@ jobs:
 
   evals:
     runs-on: ubuntu-latest
-    
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,45 +41,10 @@ jobs:
       # - name: Run tests
       #   run: pnpm test
 
-  evals:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v3
-        with:
-          version: 10
-          
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 23
-          cache: 'pnpm'
-          
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-        
-      - name: Run CI evals
-        env:
-          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-        run: pnpm eval:ci
-        
-      - name: Upload evals results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: evaluation-results
-          path: |
-            *.log
-            evaluation-*.json
-          retention-days: 30
-
   # Summary job that requires both test and evals to pass
   ci-check:
     runs-on: ubuntu-latest
-    needs: [evals, test]
+    needs: [test]
     if: always()
     
     steps:
@@ -92,13 +57,4 @@ jobs:
             exit 1
           else
             echo "✅ CI passed (tests)"
-          fi
-
-          if [[ "${{ needs.evals.result }}" == "skipped" ]]; then
-            echo "⚠️  Evaluations skipped (missing API keys)"
-          elif [[ "${{ needs.evals.result }}" != "success" ]]; then
-            echo "❌ Evaluations failed"
-            exit 1
-          else
-            echo "✅ CI passed (evaluations)"
           fi 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,8 @@ name: CI
 on:
   push:
     branches: [ main ]
-    paths:
-      - 'src/lib/ai.ts'
   pull_request:
     branches: [ main ]
-    paths:
-      - 'src/lib/ai.ts'
 
 jobs:
   test:

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -1,0 +1,42 @@
+name: Evals
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'src/lib/ai.ts'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'src/lib/ai.ts'
+
+jobs:
+  evals:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 10
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 23
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run CI evals
+        env:
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+        run: pnpm eval:ci
+      - name: Upload evals results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: evaluation-results
+          path: |
+            *.log
+            evaluation-*.json
+          retention-days: 30 


### PR DESCRIPTION
Update the CI configuration to trigger evals only when changes occur in `src/lib/ai.ts`, moving evals to a separate workflow and removing path filters for broader triggering.