### PR TITLE
feat: make command explanation and confirmation opt-in via --explain flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,13 +165,14 @@ lazyshell "your natural language command description"
 lsh "your natural language command description"
 ```
 
-### Explain Mode
+### Options
 
-By default, LazyShell generates and runs the command immediately. Use `--explain` to see an explanation and confirm before running:
+By default, LazyShell generates and runs the command immediately. Use `--explain` to see an explanation, and `--confirm` to review before running:
 
 ```bash
-lazyshell -e "find all JavaScript files"  # Show explanation and confirm before running
-lsh --explain "show disk usage"           # Same with long flag
+lazyshell -e "find all JavaScript files"  # Show explanation of the command
+lsh --confirm "show disk usage"           # Ask for confirmation before running
+lsh -e -c "delete old log files"          # Show explanation and confirm before running
 ```
 
 ### Examples

--- a/README.md
+++ b/README.md
@@ -165,11 +165,13 @@ lazyshell "your natural language command description"
 lsh "your natural language command description"
 ```
 
-### Silent Mode
+### Explain Mode
+
+By default, LazyShell generates and runs the command immediately. Use `--explain` to see an explanation and confirm before running:
 
 ```bash
-lazyshell -s "find all JavaScript files"  # No explanation, just the command
-lsh --silent "show disk usage"            # Same with long flag
+lazyshell -e "find all JavaScript files"  # Show explanation and confirm before running
+lsh --explain "show disk usage"           # Same with long flag
 ```
 
 ### Examples

--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,7 @@
         "@ai-sdk/openai-compatible": "^0.2.14",
         "@eslint/js": "^9.30.0",
         "@jest/types": "^29.6.3",
+        "@types/bun": "^1.3.11",
         "@types/node": "^22.15.34",
         "@typescript-eslint/eslint-plugin": "^8.35.1",
         "@typescript-eslint/parser": "^8.35.1",
@@ -135,6 +136,8 @@
 
     "@tsconfig/node16": ["@tsconfig/node16@1.0.4", "", {}, "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="],
 
+    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+
     "@types/diff-match-patch": ["@types/diff-match-patch@1.0.36", "", {}, "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
@@ -194,6 +197,8 @@
     "brace-expansion": ["brace-expansion@1.1.11", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "prerelease": "bun run build && npm version prerelease && npm run build && npm publish && git push --follow-tags",
     "eval:ci": "bun src/lib/ci-eval.ts",
     "prepare": "husky",
-    "compile": "bun build --compile --minify --sourcemap src/index.ts  --outfile bin/lsh"
+    "compile": "bun build --compile --minify --sourcemap src/index.ts  --outfile bin/lsh",
+    "test": "bun test"
   },
   "keywords": [
     "ai",
@@ -42,6 +43,7 @@
     "@ai-sdk/openai-compatible": "^0.2.14",
     "@eslint/js": "^9.30.0",
     "@jest/types": "^29.6.3",
+    "@types/bun": "^1.3.11",
     "@types/node": "^22.15.34",
     "@typescript-eslint/eslint-plugin": "^8.35.1",
     "@typescript-eslint/parser": "^8.35.1",

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,0 +1,79 @@
+import { describe, test, expect } from 'bun:test';
+import { Command } from 'commander';
+
+function createProgram() {
+  const program = new Command();
+  program
+    .argument('<prompt_parts...>', 'prompt')
+    .option('-e, --explain', 'show explanation of the generated command')
+    .option('-c, --confirm', 'ask for confirmation before running the command')
+    .exitOverride()
+    .action(() => {});
+
+  return program;
+}
+
+describe('CLI flag parsing', () => {
+  test('parses prompt without flags', () => {
+    const program = createProgram();
+    program.parse(['node', 'lsh', 'list', 'files']);
+
+    expect(program.args).toEqual(['list', 'files']);
+    expect(program.opts()).toEqual({});
+  });
+
+  test('parses --explain flag', () => {
+    const program = createProgram();
+    program.parse(['node', 'lsh', '--explain', 'list', 'files']);
+
+    expect(program.opts().explain).toBe(true);
+  });
+
+  test('parses -e short flag', () => {
+    const program = createProgram();
+    program.parse(['node', 'lsh', '-e', 'list', 'files']);
+
+    expect(program.opts().explain).toBe(true);
+  });
+
+  test('parses --confirm flag', () => {
+    const program = createProgram();
+    program.parse(['node', 'lsh', '--confirm', 'list', 'files']);
+
+    expect(program.opts().confirm).toBe(true);
+  });
+
+  test('parses -c short flag', () => {
+    const program = createProgram();
+    program.parse(['node', 'lsh', '-c', 'list', 'files']);
+
+    expect(program.opts().confirm).toBe(true);
+  });
+
+  test('parses both -e and -c together', () => {
+    const program = createProgram();
+    program.parse(['node', 'lsh', '-e', '-c', 'list', 'files']);
+
+    const opts = program.opts();
+    expect(opts.explain).toBe(true);
+    expect(opts.confirm).toBe(true);
+  });
+
+  test('explain and confirm default to undefined (falsy)', () => {
+    const program = createProgram();
+    program.parse(['node', 'lsh', 'hello']);
+
+    const opts = program.opts();
+    expect(opts.explain).toBeUndefined();
+    expect(opts.confirm).toBeUndefined();
+  });
+
+  test('flags work with multi-word prompts', () => {
+    const program = createProgram();
+    program.parse(['node', 'lsh', '-e', '-c', 'find', 'all', 'js', 'files']);
+
+    expect(program.opts().explain).toBe(true);
+    expect(program.opts().confirm).toBe(true);
+    expect(program.args).toEqual(['find', 'all', 'js', 'files']);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,7 @@ program
           switch (action) {
             case 'execute':
               outro(`running command: ${chalk.green(command)}`);
-              runCommand(command);
+              await runCommand(command);
               shouldContinue = false;
               break;
             case 'refine':
@@ -116,7 +116,7 @@ program
           }
         } else {
           outro(`running command: ${chalk.green(command)}`);
-          runCommand(command);
+          await runCommand(command);
           shouldContinue = false;
         }
       } catch (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,12 +57,12 @@ program
   .version(require('../package.json').version)
   .description(require('../package.json').description)
   .argument('<prompt_parts...>', 'prompt')
-  .option('-s, --silent', 'run in silent mode (no explanation)')
+  .option('-e, --explain', 'show explanation and confirm before running')
   .action(async (prompt_parts: string[], options) => {
     intro(chalk.bgBlue(chalk.black('LazyShell')));
     let currentPrompt = prompt_parts.join(' ');
     let shouldContinue = true;
-    const silent = options.silent || false;
+    const explain = options.explain || false;
 
     while (shouldContinue) {
       try {
@@ -70,7 +70,7 @@ program
 
         const spin = spinner();
         spin.start('Loading...');
-        const result = await generateCommandStruct(currentPrompt, modelConfig, !silent);
+        const result = await generateCommandStruct(currentPrompt, modelConfig, explain);
 
         spin.stop('Your command: ');
         const command = result.command.trim();
@@ -85,31 +85,37 @@ program
           await print(chalk.green('📋 Command copied to clipboard!'));
         }
 
-        const action = await select({
-          message: 'Run command?',
-          options: [
-            { label: '✅ Yes', value: 'execute' },
-            { label: '🔧 Refine', value: 'refine' },
-            { label: '❌ Cancel', value: 'cancel' },
-          ],
-        });
-        if (isCancel(action)) {
-          cancel('Operation cancelled.');
-          process.exit(0);
-        }
+        if (explain) {
+          const action = await select({
+            message: 'Run command?',
+            options: [
+              { label: '✅ Yes', value: 'execute' },
+              { label: '🔧 Refine', value: 'refine' },
+              { label: '❌ Cancel', value: 'cancel' },
+            ],
+          });
+          if (isCancel(action)) {
+            cancel('Operation cancelled.');
+            process.exit(0);
+          }
 
-        switch (action) {
-          case 'execute':
-            outro(`running command: ${chalk.green(command)}`);
-            runCommand(command);
-            shouldContinue = false;
-            break;
-          case 'refine':
-            currentPrompt = await refineCommand(currentPrompt, command);
-            break;
-          case 'cancel':
-            outro(chalk.yellow('Command cancelled.'));
-            return;
+          switch (action) {
+            case 'execute':
+              outro(`running command: ${chalk.green(command)}`);
+              runCommand(command);
+              shouldContinue = false;
+              break;
+            case 'refine':
+              currentPrompt = await refineCommand(currentPrompt, command);
+              break;
+            case 'cancel':
+              outro(chalk.yellow('Command cancelled.'));
+              return;
+          }
+        } else {
+          outro(`running command: ${chalk.green(command)}`);
+          runCommand(command);
+          shouldContinue = false;
         }
       } catch (error) {
         console.error(chalk.red(error));

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,12 +57,14 @@ program
   .version(require('../package.json').version)
   .description(require('../package.json').description)
   .argument('<prompt_parts...>', 'prompt')
-  .option('-e, --explain', 'show explanation and confirm before running')
+  .option('-e, --explain', 'show explanation of the generated command')
+  .option('-c, --confirm', 'ask for confirmation before running the command')
   .action(async (prompt_parts: string[], options) => {
     intro(chalk.bgBlue(chalk.black('LazyShell')));
     let currentPrompt = prompt_parts.join(' ');
     let shouldContinue = true;
     const explain = options.explain || false;
+    const confirm = options.confirm || false;
 
     while (shouldContinue) {
       try {
@@ -85,7 +87,7 @@ program
           await print(chalk.green('📋 Command copied to clipboard!'));
         }
 
-        if (explain) {
+        if (confirm) {
           const action = await select({
             message: 'Run command?',
             options: [

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -189,7 +189,7 @@ export type CommandWithExplanation = z.infer<typeof zCmdExp>;
 export async function generateCommandStruct(
   prompt: string,
   modelConfig?: ModelConfig,
-  explanation: boolean = true
+  explanation: boolean = false
 ): Promise<Command | CommandWithExplanation> {
   const modelConf = modelConfig || getDefaultModel();
   const schema = explanation ? zCmdExp : zCmd;

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,29 @@
+import { describe, test, expect } from 'bun:test';
+import { runCommand } from './utils';
+
+describe('runCommand', () => {
+  test('executes a simple command and resolves with exit code 0', async () => {
+    const exitCode = await runCommand('echo hello');
+    expect(exitCode).toBe(0);
+  });
+
+  test('resolves with non-zero exit code for failing commands', async () => {
+    const exitCode = await runCommand('exit 1');
+    expect(exitCode).toBe(1);
+  });
+
+  test('resolves with exit code 127 for unknown commands', async () => {
+    const exitCode = await runCommand('nonexistent_command_abc123');
+    expect(exitCode).toBe(127);
+  });
+
+  test('handles commands with arguments', async () => {
+    const exitCode = await runCommand('echo "foo bar baz"');
+    expect(exitCode).toBe(0);
+  });
+
+  test('handles piped commands', async () => {
+    const exitCode = await runCommand('echo hello | cat');
+    expect(exitCode).toBe(0);
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,32 +1,27 @@
 import * as os from 'os';
 import * as fs from 'fs';
 import * as path from 'path';
-import { exec } from 'child_process';
+import { spawn } from 'child_process';
 import { stream } from '@clack/prompts';
 import { wrapText } from './helpers/text-wrapper';
 
-export function runCommand(command: string) {
+export function runCommand(command: string): Promise<number> {
   console.log('');
-
-  const childProcess = exec(command, (error, stdout, stderr) => {
-    if (error) {
-      console.error(`Error: ${error.message}`);
-      return;
-    }
-
-    if (stderr) {
-      console.error(`stderr: ${stderr}`);
-    }
-  });
 
   appendToShellHistory(command);
 
-  childProcess.stdout?.on('data', data => {
-    process.stdout.write(data);
+  const shell = process.env.SHELL || (os.platform() === 'win32' ? 'powershell' : '/bin/sh');
+  const childProcess = spawn(shell, ['-c', command], {
+    stdio: 'inherit',
   });
 
-  childProcess.stderr?.on('data', data => {
-    process.stderr.write(data);
+  return new Promise((resolve, reject) => {
+    childProcess.on('close', code => {
+      resolve(code ?? 0);
+    });
+    childProcess.on('error', err => {
+      reject(err);
+    });
   });
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["bun-types"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->

## Summary

Makes the generated command explanation and confirmation prompt **optional, independent, and off by default**, each togglable via its own CLI flag. Also fixes broken command execution.

## Changes

### Before
- Command explanation was shown **by default** (disabled with `--silent`)
- The interactive confirmation prompt (Yes/Refine/Cancel) was **always shown**
- `runCommand` used fire-and-forget `exec()` — process could exit before command finished

### After
- **Default behavior**: generate command, display it, and **run immediately** — no explanation, no confirmation
- **`-e` / `--explain`**: show the AI-generated explanation of the command
- **`-c` / `--confirm`**: present the interactive confirmation prompt (Yes/Refine/Cancel) before executing
- Both flags are independent and can be combined
- `runCommand` now uses `spawn` with `stdio: 'inherit'` and returns a `Promise<number>` (exit code), properly awaited by the caller

### Files changed

| File | Change |
|------|--------|
| `src/index.ts` | Replaced `-s, --silent` with `-e, --explain` and `-c, --confirm`; await `runCommand` |
| `src/lib/ai.ts` | Changed `generateCommandStruct` default `explanation` param from `true` to `false` |
| `src/utils.ts` | Rewrote `runCommand` to use `spawn` + `stdio: 'inherit'`, return `Promise<number>` |
| `README.md` | Updated docs to reflect the new flags |
| `src/utils.test.ts` | Tests for `runCommand` (exit codes, pipes, args, unknown commands) |
| `src/cli.test.ts` | Tests for CLI flag parsing (`-e`, `-c`, `--explain`, `--confirm`, defaults) |
| `package.json` | Added `test` script, `@types/bun` dev dependency |
| `tsconfig.json` | Added `bun-types` for test type support |

## Usage

```bash
# Default: generate and run immediately
lsh "list files sorted by size"

# Show explanation only
lsh -e "find all JavaScript files modified in the last 7 days"

# Confirm before running only
lsh -c "show disk usage sorted by size"

# Both explanation and confirmation
lsh -e -c "delete old log files"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --explain and --confirm flags; flags can be combined.
* **Behavior Changes**
  * Commands now auto-execute by default; previous silent mode removed.
  * Explanations are off by default and shown only when --explain is used.
  * Confirmation prompt appears when --confirm is used; otherwise commands run immediately.
* **Documentation**
  * Updated usage examples and Options section to reflect new flags.
* **Tests**
  * Added CLI and command-execution unit tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->